### PR TITLE
Fix :Eval XXX starting with a ;

### DIFF
--- a/autoload/nrepl/foreplay_connection.vim
+++ b/autoload/nrepl/foreplay_connection.vim
@@ -146,7 +146,7 @@ endfunction
 
 function! s:nrepl_eval(expr, ...) dict abort
   let payload = {"op": "eval"}
-  let payload.code = '(try (eval ''(do '.a:expr.')) (catch Exception e (print (apply str (interpose "\t" (map str (.getStackTrace e))))) (throw e)))'
+  let payload.code = '(try (eval ''(do '.a:expr."\n".')) (catch Exception e (print (apply str (interpose "\t" (map str (.getStackTrace e))))) (throw e)))'
   let options = a:0 ? a:1 : {}
   if has_key(options, 'ns')
     let payload.ns = options.ns


### PR DESCRIPTION
This patch adds a newline after the input of :Eval so that if the last line of input begins with ';' it does not cause malformed input by commenting out exception handling code and unbalancing parentheses.

At first I thought by select() stuff broke it, but this turns out to be pretty simple.
