### PR TITLE
fix printing of stack trace by adding newlines

### DIFF
--- a/autoload/nrepl/foreplay_connection.vim
+++ b/autoload/nrepl/foreplay_connection.vim
@@ -146,7 +146,7 @@ endfunction
 
 function! s:nrepl_eval(expr, ...) dict abort
   let payload = {"op": "eval"}
-  let payload.code = '(try (eval ''(do '.a:expr."\n".')) (catch Exception e (print (apply str (interpose "\t" (map str (.getStackTrace e))))) (throw e)))'
+  let payload.code = '(try (eval ''(do '.a:expr."\n".')) (catch Exception e (print (apply str "\t" (interpose "\n\t" (map str (.getStackTrace e))))) (throw e)))'
   let options = a:0 ? a:1 : {}
   if has_key(options, 'ns')
     let payload.ns = options.ns


### PR DESCRIPTION
Right now since no newlines are printed, Vim tries to print the stack trace as one huge line, which doesn't show up and blocks input for around 2 seconds on my machine.

This patch fixes that by adding newlines. The resulting text will be indented by one tab as intended.
