### PR TITLE
Fixed a typo bug; gd in new tab

### DIFF
--- a/plugin/foreplay.vim
+++ b/plugin/foreplay.vim
@@ -774,7 +774,7 @@ augroup foreplay_source
   autocmd FileType clojure nmap <buffer> ]<C-D>     <Plug>ForeplayDjump
   autocmd FileType clojure nmap <buffer> <C-W><C-D> <Plug>ForeplayDsplit
   autocmd FileType clojure nmap <buffer> <C-W>d     <Plug>ForeplayDsplit
-  autocmd FileType clojure nmap <buffer> <C-W>gd    <Plug>ForeplayDtabedit
+  autocmd FileType clojure nmap <buffer> <C-W>gd    <Plug>ForeplayDtabjump
 augroup END
 
 " }}}1


### PR DESCRIPTION
Hi Tim,

There is a typo in master for jumping to a definition in a new tab.  The alias is "tabjump" but you had the old "tabedit" in there.

Fixed up in this one-liner pull request
