### PR TITLE
Decode paths for aliased namespaces.

### DIFF
--- a/plugin/foreplay.vim
+++ b/plugin/foreplay.vim
@@ -821,9 +821,9 @@ function! foreplay#findfile(path) abort
     endif
 
     let response = s:eval(printf(cmd, '"'.escape(path, '"').'"'), options)
-    let result = s:decode_url(get(split(get(response, 'value', ''), "\n"), 0, ''))
-
+    let result = get(split(get(response, 'value', ''), "\n"), 0, '')
   endif
+  let result = s:decode_url(result)
   if result ==# ''
     return foreplay#findresource(path)
   else


### PR DESCRIPTION
Currently trying to `gf` on a namespace alias opens a buffer with a path like `jar:file:/path/to/jar.jar!/path/to/file.clj`
or
`file:/path/to/file.clj`

This pull fixes that behaviour by decoding both aliased and non-aliased namespaces.
