### PR TITLE
Handle single keyword metadata on namespace name

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -998,10 +998,12 @@ function! fireplace#ns() abort
   while lnum < line('$') && getline(lnum) =~# '^\s*\%(;.*\)\=$'
     let lnum += 1
   endwhile
+  let keyword_group = '[A-Za-z0-9_?*!+/=<>.-]'
   let lines = join(getline(lnum, lnum+50), ' ')
   let lines = substitute(lines, '"\%(\\.\|[^"]\)*"\|\\.', '', 'g')
   let lines = substitute(lines, '\^\={[^{}]*}', '', '')
-  let ns = matchstr(lines, '\C^(\s*\%(in-ns\s*''\|ns\s\+\)\zs[A-Za-z0-9_?*!+/=<>.-]\+\ze')
+  let lines = substitute(lines, '\^:'.keyword_group.'\+', '', 'g')
+  let ns = matchstr(lines, '\C^(\s*\%(in-ns\s*''\|ns\s\+\)\zs'.keyword_group.'\+\ze')
   if ns !=# ''
     return ns
   endif


### PR DESCRIPTION
Namespace symbols within the `ns` macro can have metadata - this is, for example, used by lein when running only a subset of tests with `lein test :keyword`.

A ns declaration might look like:

``` clojure
(ns ^:interation ^{:slow false :skip-coverage true}
  my-namespace-name
  (:use ...))
```

The ^{} is already somewhat handled by `fireplace#ns()`, but the single keyword case breaks ns name detection.
