### PR TITLE
Macroexpand motions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -68,7 +68,8 @@ Standard stuff here.  `:Eval` evaluates a range (`:%Eval` gets the whole
 file), `:Require` requires a namespace with `:reload` (`:Require!` does
 `:reload-all`), either the current buffer or a given argument.  There's a `cp`
 operator that evaluates a given motion (`cpp` for the expression under the
-cursor).
+cursor). `cm` and `c1m` are similar, but they only run `macroexpand` and
+`macroexpand-1` instead of evaluating the form entirely.
 
 Any failed evaluation loads the stack trace into the location list, which
 can be easily accessed with `:lopen`.

--- a/doc/fireplace.txt
+++ b/doc/fireplace.txt
@@ -139,6 +139,18 @@ c!{motion}              Eval/replace the code indicated by {motion}.
 
 c!!                     Eval/replace the inner-most expr at the cusror.
 
+                                                *fireplace-cm*
+cm{motion}              Fully macroexpand the code indicated by {motion}.
+
+                                                *fireplace-cmm*
+cmm                     Fully macroexpand the inner-most expr at the cursor.
+
+                                                *fireplace-c1m*
+c1m{motion}             Macroexpand the code indicated by {motion} once.
+
+                                                *fireplace-c1mm*
+c1mm                    Macroexpand the inner-most expr at the cursor once.
+
                                                 *fireplace-cqp*
 cqp                     Bring up a prompt for code to eval/print.
 

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -538,6 +538,10 @@ function! fireplace#evalprint(expr) abort
   return fireplace#echo_session_eval(a:expr)
 endfunction
 
+function! fireplace#macroexpand(fn, form) abort
+  return fireplace#evalprint('(clojure.core/'.a:fn.' (quote '.a:form.'))')
+endfunction
+
 let g:fireplace#reader =
       \ '(symbol ((fn *vimify [x]' .
       \  ' (cond' .
@@ -611,6 +615,14 @@ function! s:filterop(type) abort
   finally
     let @@ = reg_save
   endtry
+endfunction
+
+function! s:macroexpandop(type) abort
+  call fireplace#macroexpand("macroexpand", s:opfunc(a:type))
+endfunction
+
+function! s:macroexpand1op(type) abort
+  call fireplace#macroexpand("macroexpand-1", s:opfunc(a:type))
 endfunction
 
 function! s:printop(type) abort
@@ -749,6 +761,11 @@ xnoremap <silent> <Plug>FireplacePrint  :<C-U>call <SID>printop(visualmode())<CR
 nnoremap <silent> <Plug>FireplaceFilter :<C-U>set opfunc=<SID>filterop<CR>g@
 xnoremap <silent> <Plug>FireplaceFilter :<C-U>call <SID>filterop(visualmode())<CR>
 
+nnoremap <silent> <Plug>FireplaceMacroExpand  :<C-U>set opfunc=<SID>macroexpandop<CR>g@
+xnoremap <silent> <Plug>FireplaceMacroExpand  :<C-U>call <SID>macroexpandop(visualmode())<CR>
+nnoremap <silent> <Plug>FireplaceMacroExpand1 :<C-U>set opfunc=<SID>macroexpand1op<CR>g@
+xnoremap <silent> <Plug>FireplaceMacroExpand1 :<C-U>call <SID>macroexpand1op(visualmode())<CR>
+
 nnoremap <silent> <Plug>FireplaceEdit   :<C-U>set opfunc=<SID>editop<CR>g@
 xnoremap <silent> <Plug>FireplaceEdit   :<C-U>call <SID>editop(visualmode())<CR>
 
@@ -786,6 +803,11 @@ function! s:setup_eval() abort
 
   nmap <buffer> c! <Plug>FireplaceFilter
   nmap <buffer> c!! <Plug>FireplaceFilterab
+
+  nmap <buffer> cm <Plug>FireplaceMacroExpand
+  nmap <buffer> cmm <Plug>FireplaceMacroExpandab
+  nmap <buffer> c1m <Plug>FireplaceMacroExpand1
+  nmap <buffer> c1mm <Plug>FireplaceMacroExpand1ab
 
   nmap <buffer> cq <Plug>FireplaceEdit
   nmap <buffer> cqq <Plug>FireplaceEditab


### PR DESCRIPTION
Bind cm{motion} to full macro expansion of the form under the cursor
(using clojure.core/macroexpand), and bind c1m{motion} to partial macro
expansion of the form under the cursor (using clojure.core/macroexpand-1).

As per cp{motion}, the suffix "p" will apply the expansion to the form
under the cursor.

When exploring Clojure code I find it very useful to see what macros
are doing prior to evaluation. For example, it's much easier to understand
defn once you expand it and see it's really using def to bind a name to
an anonymous fn.

This is my second attempt at implementing macroexpansion for vim-fireplace following @tpope's help with my first pull request (#69).
