### PR TITLE
Proof-of-concept of macro-based refactoring

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -99,8 +99,8 @@ Because why not?  It works in the quasi-REPL too.
 ### Refactoring
 
 If [Poker](https://github.com/ctford/poker) has been `refer`-ed in the
-nREPL session, `crut`, `crtf` and `crtl` apply unthreading, threading-first
-and threading-last refactorings to a motion. Highly experimental. 
+nREPL session, `crt`, `cru`, `crf` and `crl` apply threading, unthreading,
+threading-first and threading-last refactorings to a motion. Highly experimental. 
 
 ## FAQ
 

--- a/README.markdown
+++ b/README.markdown
@@ -96,6 +96,12 @@ Where possible, I favor enhancing built-ins over inventing a bunch of
 
 Because why not?  It works in the quasi-REPL too.
 
+### Refactoring
+
+If [Poker] has been `refer`-ed in the nREPL session, `crut`, `crtf` and
+`crtl` apply unthreading, threading-first and threading-last refactorings
+to a motion. Highly experimental. 
+
 ## FAQ
 
 > Why does it take so long for Vim to startup?

--- a/README.markdown
+++ b/README.markdown
@@ -98,9 +98,9 @@ Because why not?  It works in the quasi-REPL too.
 
 ### Refactoring
 
-If [Poker] has been `refer`-ed in the nREPL session, `crut`, `crtf` and
-`crtl` apply unthreading, threading-first and threading-last refactorings
-to a motion. Highly experimental. 
+If [Poker](https://github.com/ctford/poker) has been `refer`-ed in the
+nREPL session, `crut`, `crtf` and `crtl` apply unthreading, threading-first
+and threading-last refactorings to a motion. Highly experimental. 
 
 ## FAQ
 

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -598,10 +598,6 @@ function! s:opfunc(type) abort
   endtry
 endfunction
 
-function! s:filterop(type) abort
-  return s:replaceop(a:type, s:opfunc(a:type))
-endfunction
-
 function! s:replaceop(type, expr) abort
   let reg_save = @@
   try
@@ -614,6 +610,15 @@ function! s:replaceop(type, expr) abort
   finally
     let @@ = reg_save
   endtry
+endfunction
+
+function! s:filterop(type) abort
+  return s:replaceop(a:type, s:opfunc(a:type))
+endfunction
+
+function! s:unthreadop(type) abort
+  let expr = '(poker.refactor/unthread (quote '.s:opfunc(a:type).'))'
+  return s:replaceop(a:type, expr)
 endfunction
 
 function! s:printop(type) abort
@@ -752,6 +757,9 @@ xnoremap <silent> <Plug>FireplacePrint  :<C-U>call <SID>printop(visualmode())<CR
 nnoremap <silent> <Plug>FireplaceFilter :<C-U>set opfunc=<SID>filterop<CR>g@
 xnoremap <silent> <Plug>FireplaceFilter :<C-U>call <SID>filterop(visualmode())<CR>
 
+nnoremap <silent> <Plug>FireplaceUnthread :<C-U>set opfunc=<SID>unthreadop<CR>g@
+xnoremap <silent> <Plug>FireplaceUnthread :<C-U>call <SID>unthreadop(visualmode())<CR>
+
 nnoremap <silent> <Plug>FireplaceEdit   :<C-U>set opfunc=<SID>editop<CR>g@
 xnoremap <silent> <Plug>FireplaceEdit   :<C-U>call <SID>editop(visualmode())<CR>
 
@@ -789,6 +797,9 @@ function! s:setup_eval() abort
 
   nmap <buffer> c! <Plug>FireplaceFilter
   nmap <buffer> c!! <Plug>FireplaceFilterab
+
+  nmap <buffer> crut <Plug>FireplaceUnthread
+  nmap <buffer> crutt <Plug>FireplaceUnthreadab
 
   nmap <buffer> cq <Plug>FireplaceEdit
   nmap <buffer> cqq <Plug>FireplaceEditab

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -599,10 +599,13 @@ function! s:opfunc(type) abort
 endfunction
 
 function! s:filterop(type) abort
+  return s:replaceop(a:type, s:opfunc(a:type))
+endfunction
+
+function! s:replaceop(type, expr) abort
   let reg_save = @@
   try
-    let expr = s:opfunc(a:type)
-    let @@ = matchstr(expr, '^\n\+').fireplace#session_eval(expr).matchstr(expr, '\n\+$')
+    let @@ = matchstr(a:expr, '^\n\+').fireplace#session_eval(a:expr).matchstr(a:expr, '\n\+$')
     if @@ !~# '^\n*$'
       normal! gvp
     endif

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -621,6 +621,16 @@ function! s:unthreadop(type) abort
   return s:replaceop(a:type, expr)
 endfunction
 
+function! s:threadfirstop(type) abort
+  let expr = '(poker.refactor/thread-first (quote '.s:opfunc(a:type).'))'
+  return s:replaceop(a:type, expr)
+endfunction
+
+function! s:threadlastop(type) abort
+  let expr = '(poker.refactor/thread-last (quote '.s:opfunc(a:type).'))'
+  return s:replaceop(a:type, expr)
+endfunction
+
 function! s:printop(type) abort
   let s:todo = s:opfunc(a:type)
   call feedkeys("\<Plug>FireplacePrintLast")
@@ -759,6 +769,10 @@ xnoremap <silent> <Plug>FireplaceFilter :<C-U>call <SID>filterop(visualmode())<C
 
 nnoremap <silent> <Plug>FireplaceUnthread :<C-U>set opfunc=<SID>unthreadop<CR>g@
 xnoremap <silent> <Plug>FireplaceUnthread :<C-U>call <SID>unthreadop(visualmode())<CR>
+nnoremap <silent> <Plug>FireplaceThreadFirst :<C-U>set opfunc=<SID>threadfirstop<CR>g@
+xnoremap <silent> <Plug>FireplaceThreadFirst :<C-U>call <SID>threadfirstop(visualmode())<CR>
+nnoremap <silent> <Plug>FireplaceThreadLast :<C-U>set opfunc=<SID>threadlastop<CR>g@
+xnoremap <silent> <Plug>FireplaceThreadLast :<C-U>call <SID>threadlastop(visualmode())<CR>
 
 nnoremap <silent> <Plug>FireplaceEdit   :<C-U>set opfunc=<SID>editop<CR>g@
 xnoremap <silent> <Plug>FireplaceEdit   :<C-U>call <SID>editop(visualmode())<CR>
@@ -800,6 +814,10 @@ function! s:setup_eval() abort
 
   nmap <buffer> crut <Plug>FireplaceUnthread
   nmap <buffer> crutt <Plug>FireplaceUnthreadab
+  nmap <buffer> crtf <Plug>FireplaceThreadFirst
+  nmap <buffer> crtff <Plug>FireplaceThreadFirstab
+  nmap <buffer> crtl <Plug>FireplaceThreadLast
+  nmap <buffer> crtll <Plug>FireplaceThreadLastab
 
   nmap <buffer> cq <Plug>FireplaceEdit
   nmap <buffer> cqq <Plug>FireplaceEditab

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -631,6 +631,11 @@ function! s:threadlastop(type) abort
   return s:replaceop(a:type, expr)
 endfunction
 
+function! s:threadop(type) abort
+  let expr = '(poker.refactor/thread (quote '.s:opfunc(a:type).'))'
+  return s:replaceop(a:type, expr)
+endfunction
+
 function! s:printop(type) abort
   let s:todo = s:opfunc(a:type)
   call feedkeys("\<Plug>FireplacePrintLast")
@@ -773,6 +778,8 @@ nnoremap <silent> <Plug>FireplaceThreadFirst :<C-U>set opfunc=<SID>threadfirstop
 xnoremap <silent> <Plug>FireplaceThreadFirst :<C-U>call <SID>threadfirstop(visualmode())<CR>
 nnoremap <silent> <Plug>FireplaceThreadLast :<C-U>set opfunc=<SID>threadlastop<CR>g@
 xnoremap <silent> <Plug>FireplaceThreadLast :<C-U>call <SID>threadlastop(visualmode())<CR>
+nnoremap <silent> <Plug>FireplaceThread :<C-U>set opfunc=<SID>threadop<CR>g@
+xnoremap <silent> <Plug>FireplaceThread :<C-U>call <SID>threadop(visualmode())<CR>
 
 nnoremap <silent> <Plug>FireplaceEdit   :<C-U>set opfunc=<SID>editop<CR>g@
 xnoremap <silent> <Plug>FireplaceEdit   :<C-U>call <SID>editop(visualmode())<CR>
@@ -812,12 +819,14 @@ function! s:setup_eval() abort
   nmap <buffer> c! <Plug>FireplaceFilter
   nmap <buffer> c!! <Plug>FireplaceFilterab
 
-  nmap <buffer> crut <Plug>FireplaceUnthread
-  nmap <buffer> crutt <Plug>FireplaceUnthreadab
-  nmap <buffer> crtf <Plug>FireplaceThreadFirst
-  nmap <buffer> crtff <Plug>FireplaceThreadFirstab
-  nmap <buffer> crtl <Plug>FireplaceThreadLast
-  nmap <buffer> crtll <Plug>FireplaceThreadLastab
+  nmap <buffer> cruu <Plug>FireplaceUnthread
+  nmap <buffer> cru <Plug>FireplaceUnthreadab
+  nmap <buffer> crf <Plug>FireplaceThreadFirst
+  nmap <buffer> crff <Plug>FireplaceThreadFirstab
+  nmap <buffer> crl <Plug>FireplaceThreadLast
+  nmap <buffer> crll <Plug>FireplaceThreadLastab
+  nmap <buffer> crt <Plug>FireplaceThread
+  nmap <buffer> crtt <Plug>FireplaceThreadab
 
   nmap <buffer> cq <Plug>FireplaceEdit
   nmap <buffer> cqq <Plug>FireplaceEditab


### PR DESCRIPTION
If [Poker](https://github.com/ctford/poker) has been `require`-ed, `crut`, `crtf`, and `crtl` perform simple unthreading, threading-first and threading-last refactorings on motions.

The basic idea is that vim-fireplace should delegate to Clojure macros via nREPL for the actual refactoring. Does this seem a reasonable approach?

Things that are missing:
- auto-requiring Poker
- extracting and inlining
- making the keybindings work more like `Eval`
- formatting what comes back
