### PR TITLE
Check 'out' for repl-port if it isn't in 'target'.

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1155,10 +1155,7 @@ function! s:leiningen_connect()
   if !exists('b:leiningen_root')
     return
   endif
-  let portfile = b:leiningen_root . '/target/repl-port'
-  if !filereadable(portfile)
-    let portfile = b:leiningen_root . '/out/repl-port'
-  endif
+  let portfile = b:leiningen_root . '/' . b:repl_port_path
   if getfsize(portfile) > 0 && getftime(portfile) !=# get(s:leiningen_repl_ports, b:leiningen_root, -1)
     let port = matchstr(readfile(portfile, 'b', 1)[0], '\d\+')
     let s:leiningen_repl_ports[b:leiningen_root] = getftime(portfile)
@@ -1175,6 +1172,11 @@ function! s:leiningen_init() abort
     let root = s:hunt(expand('%:p'), 'project.clj', '(\s*defproject')
     if root !=# ''
       let b:leiningen_root = root
+      let b:repl_port_path = 'target/repl-port'
+      let target_path = matchlist(join(readfile(root . '/project.clj')), ':target-path\s*"\(.\{-}\)"')
+      if len(target_path) >= 2
+        let b:repl_port_path = target_path[1] . '/repl-port'
+      endif
     endif
   endif
   if !exists('b:leiningen_root')


### PR DESCRIPTION
When you set `:target-path` to something other than target then you have to connect manually every time.

Checking only for `out` doesn't seem right, probably this would make more sense as a setting?

The other idea that I had would be checking all directories under `b:leiningen_root` whether they have a `repl-port` in them.
