### PR TITLE
Add "Refresh" feature to make use of c.t.n.repl/refresh.

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1233,5 +1233,27 @@ augroup fireplace_leiningen
 augroup END
 
 " }}}1
+" Refresh {{{1
+function! s:Refresh(bang,ns)
+  let cmd = ('(clojure.tools.namespace.repl/refresh'.(a:bang ? '-all' : '').')')
+  echo cmd
+  try
+    call fireplace#session_eval(cmd)
+    return ''
+  catch /^Clojure:.*/
+    return ''
+  endtry
+endfunction
+
+function! s:setup_refresh()
+  command! -buffer -bar -bang -complete=customlist,fireplace#ns_complete -nargs=? Refresh :exe s:Refresh(<bang>0, <q-args>)
+  nnoremap <silent><buffer> cpf :Refresh<CR>
+endfunction
+
+augroup fireplace_refresh
+  autocmd!
+  autocmd FileType clojure call s:setup_refresh()
+augroup END
+" }}}1
 
 " vim:set et sw=2:


### PR DESCRIPTION
If your project has clojure.tools.namespace.repl, the refresh or refresh-all options may be a better option to update the nREPL. This provides a command that does just that.
