### PR TITLE
Document require on first eval.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -75,6 +75,9 @@ form entirely.
 Any failed evaluation loads the stack trace into the location list, which
 can be easily accessed with `:lopen`.
 
+Note that fireplace will `require` your current namespace on the first `:Eval`
+so your namespace and functions will be properly defined.
+
 ### Navigating and Comprehending
 
 I'm new to Clojure, so stuff that helps me understand code is a top priority.


### PR DESCRIPTION
Quick docs update to remind users that fireplace requires your namespace on first eval.
