### PR TITLE
Recognise t-.* test namespaces using :A (i.e. Midje)

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1164,11 +1164,11 @@ function! fireplace#alternates() abort
     let alt = [substitute(ns, '\.test\.', '.', '')]
   elseif ns =~# '-spec$'
     let alt = [ns[0:-6], ns . '-test']
-  elseif ns =~# '\.t-\([^\.]\)'
-    let alt = [substitute(ns, '\.t-\([^\.]\)', '\.\1', '')]
+  elseif ns =~# '\.t-[^\.]*$'
+    let alt = [substitute(ns, '\.t-\([^\.]*\)$', '\.\1', '')]
   else
     let alt = [ns . '-test', substitute(ns, '\.', '.test.', ''), ns . '-spec',
-             \ substitute(ns, '\(.*\)\.\(.*\)', '\1.t-\2', '')]
+             \ substitute(ns, '\.\([^\.]*\)$', '.t-\1', '')]
   endif
   return map(alt, 'tr(v:val, ".-", "/_") . ".clj"')
 endfunction


### PR DESCRIPTION
See issue #75

This is a very basic addition to the existing function. I contemplated allowing the user to define a pattern (or patterns), but the fact is that different projects have different testing practices..
