### PR TITLE
use string formatting supported by older pythons

### DIFF
--- a/python/nrepl_fireplace.py
+++ b/python/nrepl_fireplace.py
@@ -18,7 +18,7 @@ def vim_encode(data):
     str_list = []
     for c in data:
       if (000 <= ord(c) and ord(c) <= 037) or c == '"' or c == "\\":
-        str_list.append("\\{0:03o}".format(ord(c)))
+        str_list.append("\\%03o" % ord(c))
       else:
         str_list.append(c)
     return '"' + ''.join(str_list) + '"'


### PR DESCRIPTION
My vim was built with python 2.4.x, and I need to make this one weird change to get everything working.
