### PR TITLE
Fixing Python3 Octal Constant Compatibility Issue

### DIFF
--- a/python/nrepl_fireplace.py
+++ b/python/nrepl_fireplace.py
@@ -17,7 +17,7 @@ def vim_encode(data):
   elif isinstance(data, str):
     str_list = []
     for c in data:
-      if (000 <= ord(c) and ord(c) <= 037) or c == '"' or c == "\\":
+      if (0 <= ord(c) and ord(c) <= 31) or c == '"' or c == "\\":
         str_list.append("\\%03o" % ord(c))
       else:
         str_list.append(c)


### PR DESCRIPTION
Vim was displaying an syntax error in nrepl_fireplace.py when opening a clj file while running Python 3.3.3.  

According to http://docs.python.org/3.0/whatsnew/3.0.html, Octal constants of the form '037' were deprecated in Python 3.  The preferred form for both Python 2.6+ and Python 3 compatibility is to use '0o037'.
