### PR TITLE
Add arglists to the omnicomplete preview window

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -87,8 +87,8 @@ function! fireplace#omnicomplete(findstart, base) abort
     return col('.') - strlen(matchstr(line, '\k\+$')) - 1
   else
     try
-      let omnifier = '(fn [[k v]] (let [m (meta v)]' .
-            \ ' {:word k :menu (pr-str (:arglists m (symbol ""))) :info (str "  " (:doc m)) :kind (if (:arglists m) "f" "v")}))'
+      let omnifier = '(fn [[k v]] (let [{:keys [arglists] :as m} (meta v)]' .
+            \ ' {:word k :menu (pr-str (or arglists (symbol ""))) :info (str (when arglists (str arglists "\n")) "  " (:doc m)) :kind (if arglists "f" "v")}))'
 
       let ns = fireplace#ns()
 


### PR DESCRIPTION
When you use omnicomplete the arglists of functions are shown in the
popup menu and the docstrings in the preview window.  This patch adds
the arglists into the preview window too.  This is handy because once
you select a completion you'll still be able to see the arglists as you
write the rest of the form.
