### PR TITLE
Remove ansi colours escape codes in output

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -540,13 +540,14 @@ function! fireplace#quickfix_for(stacktrace) abort
 endfunction
 
 function! s:output_response(response) abort
+  let substitution_pat =  '\e\[[0-9;]*m\|\r\|\n$'
   if get(a:response, 'err', '') !=# ''
     echohl ErrorMSG
-    echo substitute(a:response.err, '\r\|\n$', '', 'g')
+    echo substitute(a:response.err, substitution_pat, '', 'g')
     echohl NONE
   endif
   if get(a:response, 'out', '') !=# ''
-    echo substitute(a:response.out, '\e\[[0-9;]\+m\|\r\|\n$', '', 'g')
+    echo substitute(a:response.out, substitution_pat, '', 'g')
   endif
 endfunction
 


### PR DESCRIPTION
This removes ANSI escape sequences from standard output and error.

Reasons I've hit for stdout/stderr being coloured:
- Test runner may colour output
- "pretty" printed logs when in development mode
- Some middleware may also do it (e.g.: [io.aviso.exception](https://github.com/AvisoNovate/pretty#ioavisoexception) )

So far I've avoided disabling colours in each of these cases, as they are useful when using the REPL in the terminal.
