### PR TITLE
Browser piggieback connection convenience

### DIFF
--- a/doc/fireplace.txt
+++ b/doc/fireplace.txt
@@ -40,7 +40,10 @@ properly, and that not all operations are supported.
                         cemerick.piggieback/cljs-repl with the given or
                         default (Rhino) environment.  This will also happen
                         automatically on first eval in a ClojureScript buffer
-                        if not invoked explicitly.
+                        if not invoked explicitly. If {env} is a number, the
+                        piggieback repl-env will will use a cljs.repl.browser
+                        (rather than a Rhino) env with the port set to the
+                        number provided.
 
 :Piggieback!            Terminate the most recently created piggieback
                         session.

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -212,12 +212,17 @@ function! s:repl.piggieback(arg, ...) abort
     endif
     return {}
   endif
+
+  let connection = s:conn_try(self.connection, 'clone')
   if empty(a:arg)
     let arg = ''
+  elseif a:arg =~# '^\d\{1,5}$'
+    call connection.eval("(require 'cljs.repl.browser)")
+    let port = matchstr(a:arg, '^\d\{1,5}$')
+    let arg = ' :repl-env (cljs.repl.browser/repl-env :port '.port.')'
   else
     let arg = ' :repl-env ' . a:arg
   endif
-  let connection = s:conn_try(self.connection, 'clone')
   let response = connection.eval('(cemerick.piggieback/cljs-repl'.arg.')')
 
   if empty(get(response, 'ex'))


### PR DESCRIPTION
This is mostly a sketch. So don't accept this.

Here's the idea:

```
:Piggieback browser
```

would use the common settings of http://localhost:9000 for the listener.

```
:Piggieback browser:9001
```

would use http://localhost:9001, etc.

I don't love piggiebacking on the `:Piggieback` command, but wanted to start the conversation.
