### PR TITLE
Fix sending interrupt commands after SIGINT

### DIFF
--- a/autoload/fireplace/nrepl.vim
+++ b/autoload/fireplace/nrepl.vim
@@ -125,8 +125,8 @@ function! s:nrepl_eval(expr, ...) dict abort
   elseif has_key(self, 'ns')
     let msg.ns = self.ns
   endif
-  if has_key(options, 'session')
-    let msg.session = options.session
+  if has_key(self, 'session')
+    let msg.session = self.session
   endif
   if has_key(options, 'id')
     let msg.id = options.id
@@ -147,11 +147,14 @@ function! s:nrepl_eval(expr, ...) dict abort
   endif
   try
     let response = self.process(msg)
-  catch /^Vim:Interrupt$/
-    if has_key(msg, 'session')
-      call self.message({'op': 'interrupt', 'session': msg.session, 'interrupt-id': msg.id}, 'ignore')
+    let success = 1
+  finally
+    if !exists("success")
+      if has_key(msg, 'session')
+        call self.message({'op': 'interrupt', 'session': msg.session, 'interrupt-id': msg.id}, 'ignore')
+      endif
+      throw 'Clojure: Interrupt'
     endif
-    throw 'Clojure: Interrupt'
   endtry
   if has_key(response, 'ns') && !has_key(options, 'ns')
     let self.ns = response.ns


### PR DESCRIPTION
Related to #182. I'm not really sure this is the best solution, but it works at least.

I was experimenting with the code and it appears that for some reason the `catch Vim:Interrupt` statement was never executing. I couldn't trace down why. This is sorta an ugly hack now, but I am not sure what else to try catching if Vim:Interrupt isn't working.

It also appeared from my debugging that the `options` never had the session in it, but `self` did, so I changed the code to copy the session id from `self`. Again, not sure whether `options` _should_ have it, or if this is okay/correct. Pretty new to Vimscript, so just tracing method calls is a challenge :smile:.
