### PR TITLE
Remove `:repl-env` for latest piggieback compatibility.

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -228,9 +228,9 @@ function! s:repl.piggieback(arg, ...) abort
   elseif a:arg =~# '^\d\{1,5}$'
     call connection.eval("(require 'cljs.repl.browser)")
     let port = matchstr(a:arg, '^\d\{1,5}$')
-    let arg = ' :repl-env (cljs.repl.browser/repl-env :port '.port.')'
+    let arg = ' (cljs.repl.browser/repl-env :port '.port.')'
   else
-    let arg = ' :repl-env ' . a:arg
+    let arg = ' ' . a:arg
   endif
   let response = connection.eval('(cemerick.piggieback/cljs-repl'.arg.')')
 


### PR DESCRIPTION
https://github.com/cemerick/piggieback/commit/47362bb935558db49dc906e24c5d7ba9160e4d72#diff-f31bb735cb21ecf0a8ba8ec3949a7c6aL164

Piggieback changed the `cljs-repl` function in recent version to take `repl-env` param as first param instead of a kwarg.