### PR TITLE
Cider nrepl 0.9.0 completion support

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -81,6 +81,22 @@ function! fireplace#ns_complete(A, L, P) abort
   return filter(map(matches, 's:to_ns(v:val)'), 'a:A ==# "" || a:A ==# v:val[0 : strlen(a:A)-1]')
 endfunction
 
+let s:short_types = {
+      \ 'function': 'f',
+      \ 'macro': 'm',
+      \ 'var': 'v',
+      \ 'special-form': 's',
+      \ 'class': 'c'
+      \ }
+
+function! s:candidate(val) abort
+  let type = get(a:val, 'type', '')
+  return {
+        \ 'word': get(a:val, 'candidate'),
+        \ 'kind': get(s:short_types, type, type)
+        \ }
+endfunction
+
 function! fireplace#omnicomplete(findstart, base) abort
   if a:findstart
     let line = getline('.')[0 : col('.')-2]
@@ -93,7 +109,9 @@ function! fireplace#omnicomplete(findstart, base) abort
         let trans = '{"word": (v:val =~# ''[./]'' ? "" : matchstr(a:base, ''^.\+/'')) . v:val}'
         let value = get(response[0], 'value', get(response[0], 'completions'))
         if type(value) == type([])
-          if type(get(value, 0)) == type([])
+          if type(get(value, 0)) == type({})
+            return map(value, 's:candidate(v:val)')
+          elseif type(get(value, 0)) == type([])
             return map(value[0], trans)
           elseif type(get(value, 0)) == type('')
             return map(value, trans)

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -91,9 +91,12 @@ let s:short_types = {
 
 function! s:candidate(val) abort
   let type = get(a:val, 'type', '')
+  let arglists = get(a:val, 'arglists', [])
   return {
         \ 'word': get(a:val, 'candidate'),
-        \ 'kind': get(s:short_types, type, type)
+        \ 'kind': get(s:short_types, type, type),
+        \ 'info': get(a:val, 'doc', ''),
+        \ 'menu': empty(arglists) ? '' : '(' . join(arglists, ' ') . ')'
         \ }
 endfunction
 
@@ -105,7 +108,7 @@ function! fireplace#omnicomplete(findstart, base) abort
     try
 
       if fireplace#op_available('complete')
-        let response = fireplace#message({'op': 'complete', 'symbol': a:base})
+        let response = fireplace#message({'op': 'complete', 'symbol': a:base, 'extra-metadata': ['arglists', 'doc']})
         let trans = '{"word": (v:val =~# ''[./]'' ? "" : matchstr(a:base, ''^.\+/'')) . v:val}'
         let value = get(response[0], 'value', get(response[0], 'completions'))
         if type(value) == type([])


### PR DESCRIPTION
Hi,

This is a culmination of changes I contributed to cider-nrepl, compliment and cljs-tooling.

Firstly this adds support for Cider-nrepl complete operation which now returns a list of maps. Secondly, this uses new extra-metadata option to request arglists and docstring data for results so that those can be displayed on omnicomplete. Omnicomplete menu should now display nearly the same data with or without cider-nrepl.

![Screenshot](https://www.dropbox.com/s/tac3fnlhixpqkus/Screenshot%20from%202015-05-15%2023%3A11%3A01.png?dl=1)

Thoughts:
- Should there be an option to toggle displaying arglists on omnicomplete menu?
- Should docstring only be requested if user has preview completeopt enabled? Requesting unnecessary data has a small performance hit.