### PR TITLE
Add all candidate types to short_types map

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -86,7 +86,15 @@ let s:short_types = {
       \ 'macro': 'm',
       \ 'var': 'v',
       \ 'special-form': 's',
-      \ 'class': 'c'
+      \ 'class': 'c',
+      \ 'keyword': 'k',
+      \ 'local': 'l',
+      \ 'namespace': 'n',
+      \ 'field': 'i',
+      \ 'method': 'f',
+      \ 'static-field': 'i',
+      \ 'static-method': 'f',
+      \ 'resource': 'r'
       \ }
 
 function! s:candidate(val) abort


### PR DESCRIPTION
I missed some types in #210 so here are the rest.

I decided to use 'i' for field and static-field as 'f' is already used.