### PR TITLE
fix for #208

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1467,6 +1467,7 @@ function! fireplace#capture_test_run(expr, ...) abort
         \ .    ' (:fail :error)'
         \ .    ' (let [{file :file line :line test :name} (meta (last clojure.test/*testing-vars*))]'
         \ .      ' (clojure.test/with-test-out'
+        \ .        ' (clojure.test/inc-report-counter (:type m))'
         \ .        ' (println (clojure.string/join "\t" [file line (name (:type m)) test]))'
         \ .        ' (when (seq clojure.test/*testing-contexts*) (println (clojure.test/testing-contexts-str)))'
         \ .        ' (when-let [message (:message m)] (println message))'


### PR DESCRIPTION
The report counter needs to be updated if a test fails or
has an error.