### PR TITLE
Use 'user' namespace for class path, testing and evalparse operations.

### DIFF
--- a/autoload/fireplace/nrepl.vim
+++ b/autoload/fireplace/nrepl.vim
@@ -40,7 +40,8 @@ function! fireplace#nrepl#for(transport) abort
   endif
   " Handle boot, which sets a fake.class.path entry
   let response = client.process({'op': 'eval', 'code':
-        \ '[(System/getProperty "path.separator") (System/getProperty "fake.class.path")]', 'session': ''})
+        \ '[(System/getProperty "path.separator") (System/getProperty "fake.class.path")]', 'session': '',
+        \ 'ns': 'user'})
   let cpath = response.value[-1][5:-2]
   if cpath !=# 'nil'
     let cpath = eval(cpath)


### PR DESCRIPTION
Similar to https://github.com/tpope/vim-leiningen/pull/9.

Notes:
- The unit testing commands now provides the current namespace to clojure.test/run-tests
- use `ns-resolve` with explicit namespace over `resolve`