### PR TITLE
Remove superfluous padding from expression

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -849,7 +849,11 @@ function! s:opfunc(type) abort
       silent exe "normal! `[v`]y"
     endif
     redraw
-    return repeat("\n", line("'<")-1) . repeat(" ", col("'<")-1) . @@
+    if fireplace#client().user_ns() ==# 'user'
+      return repeat("\n", line("'<")-1) . repeat(" ", col("'<")-1) . @@
+    else
+      return @@
+    endif
   finally
     let @@ = reg_save
     let &selection = sel_save


### PR DESCRIPTION
Related to #220.
Not entirely sure if its safe to remove now. But after this piggiebacked `cpp` seems to be working normal again!