### PR TITLE
Run (single) test under cursor with fixtures applied

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1618,7 +1618,7 @@ function! s:RunTests(bang, count, ...) abort
     let vars = filter(copy(reqs), 'v:val =~# "/"')
     let nses = filter(copy(reqs), 'v:val !~# "/"')
     if len(vars) == 1
-      call add(expr, '(clojure.test/test-var #' . vars[0] . ')')
+      call add(expr, '(clojure.test/test-vars [#' . vars[0] . '])')
     elseif !empty(vars)
       call add(expr, join(['(clojure.test/test-vars'] + map(vars, '"#".v:val'), ' ').')')
     endif


### PR DESCRIPTION
Use `test-vars` instead of `test-var` so the test runs with the fixtures applied. That's the expected behavior when running a test. It's also what's being done when multiple tests are matched.

As an example:

```clojure
(require '[clojure.test :refer :all])

(def ^:dynamic *a* 0)

(defn set-a1 [f]
  (binding [*a* 1]
    (f)))

(use-fixtures :each set-a1)

(deftest a-test
  (is (= *a* 1)))

(test-var #'a-test) ;=> FAIL

(test-vars [#'a-test]) ;=> OK
```