### PR TITLE
Change :Piggieback behavior for empty/port parameters

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -277,15 +277,19 @@ function! s:repl.piggieback(arg, ...) abort
 
   let connection = s:conn_try(self.connection, 'clone')
   if empty(a:arg)
-    let arg = ''
+    let arg = '(cljs.repl.rhino/repl-env)'
   elseif a:arg =~# '^\d\{1,5}$'
-    call connection.eval("(require 'cljs.repl.browser)")
+    let replns = 'weasel.repl.websocket'
+    if has_key(connection.eval("(require '" . replns . ")"), 'ex')
+      let replns = 'cljs.repl.browser'
+      call connection.eval("(require '" . replns . ")")
+    endif
     let port = matchstr(a:arg, '^\d\{1,5}$')
-    let arg = ' (cljs.repl.browser/repl-env :port '.port.')'
+    let arg = '('.replns.'/repl-env :port '.port.')'
   else
-    let arg = ' ' . a:arg
+    let arg = a:arg
   endif
-  let response = connection.eval('(cemerick.piggieback/cljs-repl'.arg.')')
+  let response = connection.eval('(cemerick.piggieback/cljs-repl'.' '.arg.')')
 
   if empty(get(response, 'ex'))
     call insert(self.piggiebacks, extend({'connection': connection}, deepcopy(s:piggieback)))


### PR DESCRIPTION
  - Use Rhino REPL when no parameters are provided
  - Use Weasel REPL when port parameter is specified