### PR TITLE
Handle new/old nREPL stacktraces - fixes #258

### DIFF
--- a/autoload/fireplace/nrepl.vim
+++ b/autoload/fireplace/nrepl.vim
@@ -182,7 +182,12 @@ endfunction
 
 function! s:extract_last_stacktrace(nrepl, session) abort
   if a:nrepl.has_op('stacktrace')
-    let stacktrace = filter(a:nrepl.message({'op': 'stacktrace', 'session': a:session}), 'has_key(v:val, "file")')
+    let stacktrace = a:nrepl.message({'op': 'stacktrace', 'session': a:session})
+    if len(stacktrace) > 0 && has_key(stacktrace[0], 'stacktrace')
+      let stacktrace = stacktrace[0].stacktrace
+    endif
+
+    call filter(stacktrace, 'has_key(v:val, "file")')
     if !empty(stacktrace)
       return map(stacktrace, 'v:val.class.".".v:val.method."(".v:val.file.":".v:val.line.")"')
     endif


### PR DESCRIPTION
At some point there was an upstream change to the message format that
cider-nrepl returned. This resulted in in a crash when trying to eval
an expression that threw an exception, resulting in the exception
being obscured by a Vim error, and no stacktrace being produced.
This patch inspects the returned payload and optionally extracts
any embedded stacktrace before processing.