### PR TITLE
Do not reload the current ns with ct/report re-bound

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1651,6 +1651,7 @@ augroup END
 
 function! fireplace#capture_test_run(expr, ...) abort
   let expr = '(try'
+        \ . ' ' . (a:0 ? a:1 : '')
         \ . ' (require ''clojure.test)'
         \ . ' (binding [clojure.test/report (fn [m]'
         \ .  ' (case (:type m)'
@@ -1664,7 +1665,7 @@ function! fireplace#capture_test_run(expr, ...) abort
         \ .        ' (println "expected:" (pr-str (:expected m)))'
         \ .        ' (println "  actual:" (pr-str (:actual m)))))'
         \ .    ' ((.getRawRoot #''clojure.test/report) m)))]'
-        \ . ' ' . (a:0 ? a:1 : '') . a:expr . ')'
+        \ . ' ' . a:expr . ')'
         \ . ' (catch Exception e'
         \ . '   (println (str e))'
         \ . '   (println (clojure.string/join "\n" (.getStackTrace e)))))'


### PR DESCRIPTION
`RunTests` (and thus `cpr` on a clj file) does basically two things: it reloads the current namespace via `(require .... :reload)` and then runs the tests in the current ns with `(clojure.test/run-all-tests)`. But to
improve the output in case of a test failure it rebinds clojure.test/report to a new function that prints the output nicely.

clojure.test/report is a multimethod, but this new fn is not, so when there is a defmethod in the current namespace the `(require ... :reload)` fails due to an exception that looks like:

```
java.lang.ClassCastException: foo.core_test$eval3669$fn__3670 cannot be cast to clojure.lang.MultiFn, compiling:(foo/core_test.clj:5:1)
```

This change fixes this issue by doing the `(require ... :reload)` before binding clojure.test/report to a new fn.

An example of a library where this happens is test.check: github.com/clojure/test.check/blob/dd13277f7/src/main/clojure/clojure/test/check/clojure_test.cljc#L134

I created a repository to easily reproduce the issue in https://github.com/nberger/defmethod-vim-fireplace