### PR TITLE
fix clojurescript evaluation with :Eval and to disconnect repl at Piggieback!

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1064,7 +1064,12 @@ function! s:Eval(bang, line1, line2, count, args) abort
       return ''
     endif
     let options.file_path = s:buffer_path()
-    let expr = repeat("\n", line1-1).repeat(" ", col1-1)
+    if expand('%:e') ==# 'cljs'
+      "leading line feed don't work on cljs repl
+      let expr = ''
+    else
+      let expr = repeat("\n", line1-1).repeat(" ", col1-1)
+    endif
     if line1 == line2
       let expr .= getline(line1)[col1-1 : col2-1]
     else

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -270,6 +270,7 @@ let s:piggieback = copy(s:repl)
 function! s:repl.piggieback(arg, ...) abort
   if a:0 && a:1
     if len(self.piggiebacks)
+      let result = fireplace#session_eval(':cljs/quit', {})
       call remove(self.piggiebacks, 0)
     endif
     return {}


### PR DESCRIPTION
Hi,

I found that mapping :Eval is not working and found that leading line feed is send along.
And I modify the Piggieback! to disconnect clojurescript repl, so that I can reconnect later.

Thanks for having a look and let me know if I break other use cases