### PR TITLE
Fix run test under cursor in tests with metadata

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1726,7 +1726,7 @@ function! s:RunTests(bang, count, ...) abort
     else
       let args = [fireplace#ns()]
       if a:count
-        let pattern = '^\s*(def\k*\s\+' . '\%(\^:\h\k*\s\+\)*' . '\(\h\k*\)'
+        let pattern = '^\s*(def\k*\s\+' . '\%(\^:\k+\s\+\)*' . '\(\h\k*\)'
         let line = search(pattern, 'bcWn')
         if line
           let args[0] .= '/' . matchlist(getline(line), pattern)[1]

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1726,7 +1726,7 @@ function! s:RunTests(bang, count, ...) abort
     else
       let args = [fireplace#ns()]
       if a:count
-        let pattern = '^\s*(def\k*\s\+\(\h\k*\)'
+        let pattern = '^\s*(def\k*\s\+' . '\%(\^:\h\k*\s\+\)*' . '\(\h\k*\)'
         let line = search(pattern, 'bcWn')
         if line
           let args[0] .= '/' . matchlist(getline(line), pattern)[1]


### PR DESCRIPTION
The pattern used to find the test under cursor fails to match when the deftest has metadata in the test var, like in `(deftest ^:slow slow-test)`. Upon failure, it continues searching backwards, usually matching a previous deftest or any other def

The matching is fixed by adding an optional non-capturing group that matches metadata added as `^:some-metadata`. Other ways to add metadata (type-hint or metadata map) will still make the pattern to fail, however they are not very common when metadata is added to a test var.
