### PR TITLE
Correct check for macro/arglists key in docs

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1641,7 +1641,7 @@ function! s:Doc(symbol) abort
     echo info['forms-str']
   endif
 
-  if get(info, 'arglists-str', 'nil') !=# 'nil'
+  if get(info, 'arglists-str', '') !=# ''
     echo info['arglists-str']
   endif
 
@@ -1656,7 +1656,7 @@ function! s:Doc(symbol) abort
       endif
     endif
 
-  elseif get(info, 'macro', 'nil') !=# 'nil'
+  elseif get(info, 'macro', '') !=# ''
     echo "Macro"
   endif
 


### PR DESCRIPTION
I noticed that every function was a Macro, this fixed that. Also noticed that vars were printing an extra newline for arg lists.

I'm not sure this change is particularly complete, as there seem to be other surrounding lines that check for `''` but I am not sure.

This seems to work both with and without info op.

---

I think the core problem is a difference in operation between the info op and the custom code. The info op doesn't include the key if it is not applicable/present, whereas we put it as nil, which translates to `''` in vimscript.

I think we were expecting `nil` to become `'nil'` in vimscript.

It would be better to use something like `cond->` to build up a map which looks more like that the 'info' op produces.
