### PR TITLE
Docs: Mention how to start nREPL with Leiningen

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,11 +30,10 @@ This list isn't exhaustive; see the `:help` for details.
 ### Transparent setup
 
 Fireplace.vim talks to nREPL.  With Leiningen, it connects automatically using
-the `.nrepl-port` file created when you run `lein repl`. If you
-are starting nREPL some other way, run `:Connect` and enter the host and port.
-You can connect to
-multiple instances of nREPL for different projects, and it will use the right
-one automatically.  ClojureScript support is just as seamless with
+the `.nrepl-port` file created when you run `lein repl`. If you are starting
+nREPL some other way, run `:Connect` and enter the host and port.  You can
+connect to multiple instances of nREPL for different projects, and it will use
+the right one automatically.  ClojureScript support is just as seamless with
 [Piggieback][].
 
 The only external dependency is that you have either a Vim with Python support

--- a/README.markdown
+++ b/README.markdown
@@ -29,8 +29,10 @@ This list isn't exhaustive; see the `:help` for details.
 
 ### Transparent setup
 
-Fireplace.vim talks to nREPL.  With Leiningen, it connects automatically based
-on `.nrepl-port`, otherwise it's just a `:Connect` away.  You can connect to
+Fireplace.vim talks to nREPL.  With Leiningen, it connects automatically using
+the `.nrepl-port` file created when you run `lein repl`. If you
+are starting nREPL some other way, run `:Connect` and enter the host and port.
+You can connect to
 multiple instances of nREPL for different projects, and it will use the right
 one automatically.  ClojureScript support is just as seamless with
 [Piggieback][].


### PR DESCRIPTION
This adds mention of `lein repl` to the README. As a new Clojure user, it wasn't clear to me where `.nrepl-port` came from.