### PR TITLE
Fix context-aware completion from the middle of a word

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -138,7 +138,7 @@ function! s:get_complete_context() abort
           \ + col('.')
   endif
 
-  return strpart(expr, 0, p) . '__prefix__' . strpart(expr, p)
+  return strpart(expr, 0, p) . ' __prefix__ ' . strpart(expr, p)
 endfunction
 
 function! fireplace#omnicomplete(findstart, base) abort


### PR DESCRIPTION
Context-aware completion does not work well if it's triggered from the middle of a word.

<img width="570" alt="screen shot 2017-01-12 at 11 08 03 pm" src="https://cloud.githubusercontent.com/assets/700826/21893072/e1b4d628-d91c-11e6-9729-b683a9a40dd2.png">

<img width="570" alt="screen shot 2017-01-12 at 11 08 22 pm" src="https://cloud.githubusercontent.com/assets/700826/21893094/f80933ba-d91c-11e6-95bf-a2a2fdeadff1.png">

<img width="570" alt="screen shot 2017-01-12 at 11 08 56 pm" src="https://cloud.githubusercontent.com/assets/700826/21893114/0d89940a-d91d-11e6-80fa-b4ef2acd2b89.png">

<img width="570" alt="screen shot 2017-01-12 at 11 09 38 pm" src="https://cloud.githubusercontent.com/assets/700826/21893126/168c14ba-d91d-11e6-89da-2d262de8508b.png">

It is because the placeholder expression `__prefix__` is not properly generated in those cases:

- `(ns user   (:import __prefix__Lust))`
- `(__prefix__obj)`

An easy way to fix this is to append a single space to break the word. I can confirm that the patch works pretty well.
<img width="570" alt="screen shot 2017-01-12 at 11 10 07 pm" src="https://cloud.githubusercontent.com/assets/700826/21893432/5b2e61ee-d91e-11e6-9ba3-ff27b5dd915a.png">

<img width="570" alt="screen shot 2017-01-12 at 11 26 26 pm" src="https://cloud.githubusercontent.com/assets/700826/21893492/93b48552-d91e-11e6-82cd-836db7e78a00.png">




