### PR TITLE
Add pprint to cpp [#262]

### DIFF
--- a/autoload/fireplace/nrepl.vim
+++ b/autoload/fireplace/nrepl.vim
@@ -132,25 +132,19 @@ function! s:nrepl_eval(expr, ...) dict abort
   let msg = {"op": "eval"}
   let msg.code = a:expr
   let options = a:0 ? a:1 : {}
-  if has_key(options, 'ns')
-    let msg.ns = options.ns
-  elseif has_key(self, 'ns')
+
+  for [k, v] in items(options)
+    let msg[tr(k, '_', '-')] = v
+  endfor
+
+  if !has_key(msg, 'ns') && has_key(self, 'ns')
     let msg.ns = self.ns
   endif
-  if has_key(options, 'session')
-    let msg.session = options.session
-  endif
-  if has_key(options, 'id')
-    let msg.id = options.id
-  else
+
+  if !has_key(msg, 'id')
     let msg.id = fireplace#nrepl#next_id()
   endif
-  let pprint_opts = ['pprint', 'pprint-fn', 'print-length', 'print-level', 'print-meta', 'print-right-margin']
-  for popt in pprint_opts
-    if has_key(options, popt)
-      let msg[popt] = options[popt]
-    endif
-  endfor
+
   if has_key(options, 'file_path')
     let msg.op = 'load-file'
     let msg['file-path'] = options.file_path

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -781,7 +781,7 @@ function! s:temp_response(response) abort
     let output = map(split(a:response.out, "\n"), '";".v:val')
   endif
   if has_key(a:response, 'value')
-    let output += [a:response.value]
+    let output += split(a:response.value, "\n")
   endif
   let temp = tempname().'.clj'
   call writefile(output, temp)
@@ -1131,7 +1131,7 @@ function! s:Eval(bang, line1, line2, count, args) abort
     catch /^Clojure:/
     endtry
   else
-    call fireplace#echo_session_eval(expr, options)
+    call fireplace#echo_session_eval(expr, s:add_pprint_opts(options))
   endif
   return ''
 endfunction

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1043,17 +1043,17 @@ endfunction
 
 function! s:add_pprint_opts(msg)
   let a:msg.pprint = 1
-  let a:msg['pprint-fn'] = g:fireplace_pprint_fn
+  let a:msg.pprint_fn = g:fireplace_pprint_fn
   let l:max_right_margin = get(g:, 'fireplace_print_right_margin', &columns)
-  let a:msg['print-right-margin'] = min([l:max_right_margin, &columns])
+  let a:msg.print_right_margin = min([l:max_right_margin, &columns])
   if exists("g:fireplace_print_length")
-    let a:msg['print-length'] = g:fireplace_print_length
+    let a:msg.print_length = g:fireplace_print_length
   endif
   if exists("g:fireplace_print_level")
-    let a:msg['print-level'] = g:fireplace_print_level
+    let a:msg.print_level = g:fireplace_print_level
   endif
   if exists("g:fireplace_print_meta")
-    let a:msg['print-meta'] = g:fireplace_print_meta
+    let a:msg.print_meta = g:fireplace_print_meta
   endif
   return a:msg
 endfunction

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -8,6 +8,12 @@ if exists("g:loaded_fireplace") || v:version < 700 || &cp
 endif
 let g:loaded_fireplace = 1
 
+" Available when using CIDER:
+" * clojure.pprint/pprint
+" * cider.nrepl.middleware.pprint/fipp-pprint
+" * cider.nrepl.middleware.pprint/puget-pprint
+let g:fireplace_pprint_fn = 'cider.nrepl.middleware.pprint/fipp-pprint'
+
 " Section: File type
 
 augroup fireplace_file_type
@@ -1035,8 +1041,25 @@ function! s:printop(type) abort
   call feedkeys("\<Plug>FireplacePrintLast")
 endfunction
 
+function! s:add_pprint_opts(msg)
+  let a:msg.pprint = 1
+  let a:msg['pprint-fn'] = g:fireplace_pprint_fn
+  let l:max_right_margin = get(g:, 'fireplace_print_right_margin', &columns)
+  let a:msg['print-right-margin'] = min([l:max_right_margin, &columns])
+  if exists("g:fireplace_print_length")
+    let a:msg['print-length'] = g:fireplace_print_length
+  endif
+  if exists("g:fireplace_print_level")
+    let a:msg['print-level'] = g:fireplace_print_level
+  endif
+  if exists("g:fireplace_print_meta")
+    let a:msg['print-meta'] = g:fireplace_print_meta
+  endif
+  return a:msg
+endfunction
+
 function! s:print_last() abort
-  call fireplace#echo_session_eval(s:todo, {'file_path': s:buffer_path()})
+  call fireplace#echo_session_eval(s:todo, s:add_pprint_opts({'file_path': s:buffer_path()}))
   return ''
 endfunction
 


### PR DESCRIPTION
The default is the same as what CIDER.el uses, and seems sensible. I got
significantly better results using fipp than clojure.pprint

This could be extended to other evaluations quite easily too, I think `:Eval`
would benefit, but I only matched the suggestion you made in #262