### PR TITLE
Tweak README to reflect that .nrepl-port is also created by Boot

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,12 +29,12 @@ This list isn't exhaustive; see the `:help` for details.
 
 ### Transparent setup
 
-Fireplace.vim talks to nREPL.  With Leiningen, it connects automatically using
-the `.nrepl-port` file created when you run `lein repl`. If you are starting
-nREPL some other way, run `:Connect` and enter the host and port.  You can
-connect to multiple instances of nREPL for different projects, and it will use
-the right one automatically.  ClojureScript support is just as seamless with
-[Piggieback][].
+Fireplace.vim talks to nREPL.  With Leiningen and Boot, it connects
+automatically using the `.nrepl-port` file created when you run `lein repl` or
+`boot repl`. If you are starting nREPL some other way, run `:Connect` and enter
+the host and port.  You can connect to multiple instances of nREPL for different
+projects, and it will use the right one automatically.  ClojureScript support is
+just as seamless with [Piggieback][].
 
 The only external dependency is that you have either a Vim with Python support
 compiled in, or `python` in your path.


### PR DESCRIPTION
I use Boot and vim-fireplace with vim-salve, and I can attest that Boot creates `.nrepl-port` when starting a REPL via `boot repl`, which vim-fireplace/vim-salve then picks up on. There is no need to run `:Connect 12345` when using Boot.