### PR TITLE
Add support for piggieback 0.3.1+

### DIFF
--- a/doc/fireplace.txt
+++ b/doc/fireplace.txt
@@ -37,12 +37,12 @@ properly, and that not all operations are supported.
 
                                                 *fireplace-:Piggieback*
 :Piggieback [{env}]     Create a new nREPL session and invoke
-                        cemerick.piggieback/cljs-repl with the given or
-                        default (Rhino) environment.  This will also happen
+                        cider.piggieback/cljs-repl with the given or
+                        default (Nashorn) environment.  This will also happen
                         automatically on first eval in a ClojureScript buffer
                         if not invoked explicitly. If {env} is a number, the
                         piggieback repl-env will will use a cljs.repl.browser
-                        (rather than a Rhino) env with the port set to the
+                        (rather than a Nashorn) env with the port set to the
                         number provided.
 
 :Piggieback!            Terminate the most recently created piggieback

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -308,7 +308,8 @@ function! s:repl.piggieback(arg, ...) abort
 
   let connection = s:conn_try(self.connection, 'clone')
   if empty(a:arg)
-    let arg = '(cljs.repl.rhino/repl-env)'
+    call connection.eval("(require 'cljs.repl.nashorn)")
+    let arg = '(cljs.repl.nashorn/repl-env)'
   elseif a:arg =~# '^\d\{1,5}$'
     let replns = 'weasel.repl.websocket'
     if has_key(connection.eval("(require '" . replns . ")"), 'ex')
@@ -320,7 +321,9 @@ function! s:repl.piggieback(arg, ...) abort
   else
     let arg = a:arg
   endif
-  let response = connection.eval('(cemerick.piggieback/cljs-repl'.' '.arg.')')
+  let response = connection.eval("((or (resolve 'cider.piggieback/cljs-repl)"
+        \ ."(resolve 'cemerick.piggieback/cljs-repl))"
+        \ .' '.arg.')')
 
   if empty(get(response, 'ex'))
     call insert(self.piggiebacks, extend({'connection': connection}, deepcopy(s:piggieback)))


### PR DESCRIPTION
The new piggieback can be found at https://github.com/clojure-emacs/piggieback

They have dropped support for Rhino, as it was supported by a number of
horrible hacks. Instead Nashorn is recommended as the default.

The old piggieback is still supported, and in the case you're using the old
piggieback & don't have nashorn available, you can manually call out to rhino.
The latest Clojure survey suggests that a large number of Clojure users do have
nashorn available.

Nashorn definitely works as of this commit, so close #243