### PR TITLE
Fix vim hanging forever on exit

### DIFF
--- a/autoload/fireplace/nrepl_connection.vim
+++ b/autoload/fireplace/nrepl_connection.vim
@@ -105,10 +105,16 @@ endfunction
 
 function! s:nrepl_transport_call(msg, terms, sels, ...) dict abort
   let payload = fireplace#nrepl_connection#bencode(a:msg)
+
+  if a:0 && a:1 ==# 'ignore'
+    call self.dispatch('send', payload)
+    return
+  endif
+
   let response = self.dispatch('call', payload, a:terms, a:sels)
   if !a:0
     return response
-  elseif a:1 !=# 'ignore'
+  else
     return map(response, 'fireplace#nrepl#callback(v:val, "synchronous", a:000)')
   endif
 endfunction


### PR DESCRIPTION
During my workday it often happens that when i close vim - it hangs forever, today i dived into the problem and found that when you do `{'op': 'close'}` with arbitrary `session` value - nrepl just hangs.

So i came with this solution, it's a bit disrespectful to say something to nrepl server and not waiting for the answer, but it fixes my issue, maybe there is another way to fix that.

How to reproduce the bug:
- Start nrepl
- Connect to this repl from vim
- Restart nrepl
- Connect to this repl from same vim instance
- Exit vim
- ... vim hangs forever