### PR TITLE
Skip cider format when in a comment

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -1654,7 +1654,7 @@ augroup END
 " Section: Formatting
 
 function! fireplace#format(lnum, count, char) abort
-  if mode() =~# '[iR]'
+  if mode() =~# '[iR]' || getline(a:lnum) =~# '^\s*;'
     return -1
   endif
   let reg_save = @@


### PR DESCRIPTION
This allows the `gq` map to wrap lines

Closes https://github.com/tpope/vim-fireplace/issues/299