### PR TITLE
fix a few hangs due to missing terminators

### DIFF
--- a/python/nrepl_fireplace.py
+++ b/python/nrepl_fireplace.py
@@ -108,7 +108,7 @@ class Connection:
             response = self.receive()
             if "stacktrace" in response and "status" not in response:
                 response["status"] = ["done"]
-            if "changed-namespaces" in response and "status" not in response:
+            if "changed-namespaces" in response:
                 response["status"] = ["done"]
             for key in selectors:
                 if response[key] != selectors[key]:

--- a/python/nrepl_fireplace.py
+++ b/python/nrepl_fireplace.py
@@ -106,6 +106,10 @@ class Connection:
         responses = []
         while True:
             response = self.receive()
+            if "stacktrace" in response and "status" not in response:
+                response["status"] = ["done"]
+            if "changed-namespaces" in response and "status" not in response:
+                response["status"] = ["done"]
             for key in selectors:
                 if response[key] != selectors[key]:
                     continue


### PR DESCRIPTION
Like many other people I keep getting unexplainable hangs, so I decided to do some debugging. It turns out that vim-fireplace expects a `status: ["done"]` inside the return message as a terminator, but there are  last messages returned that don't have this.

So far I found 2:
1. If you break something during a `:Require`, like a wrong symbol, It tries to fetch a strack trace, which returns one without this terminator.
2. Randomly (?) it tries to return this packet as the last message:
```
RESPONSE:
{'changed-namespaces': {},
 'id': 'fireplace-hostname-1538883267-20',
 'repl-type': 'clj',
 'session': '2b7e5a1e-748b-40c9-b65e-9a9b2c7c49a2',
}
```

I am using cider-nrepl 0.18.0 if that makes a difference.

I am not sure what is the "truly correct" way, but the fix seems simple and safe enough. The truly correct way seems to be rewrite vim-fireplace using a persistent connection and command stream, but that seems really hard / impossible to do...

This patch detects these message and places the missing terminator if there is not a status.