### PR TITLE
Implement choosing between python2 and python3

### DIFF
--- a/python/nrepl_fireplace_loader.py
+++ b/python/nrepl_fireplace_loader.py
@@ -1,0 +1,26 @@
+import vim
+
+
+def fireplace_let(var, value):
+    return vim.command("let " + var + " = " + nrepl_fireplace.vim_encode(value))
+
+
+def fireplace_check():
+    vim.eval("getchar(1)")
+
+
+def fireplace_repl_dispatch(command, *args):
+    try:
+        fireplace_let(
+            "out",
+            nrepl_fireplace.dispatch(
+                vim.eval("self.host"),
+                vim.eval("self.port"),
+                fireplace_check,
+                None,
+                command,
+                *args
+            ),
+        )
+    except Exception as e:
+        fireplace_let("err", str(e))


### PR DESCRIPTION
This patch replaces all hardcoded usage of python2 with variables so that one can select between Python 2 and 3. It prefers Python 3 as I think that is the future and Python 2 retires in 2020.

I did this patch while trying to diagnose hangs and thought it might be useful if we need to switch between the two version of Python.

One thing that might be sub-optimal is that I had to move some code to a new file as I don't think you can use `:exe` with `python << EOF`