### PR TITLE
Add g:fireplace_cljs_repl_option to control default CLJS REPL

### DIFF
--- a/doc/fireplace.txt
+++ b/doc/fireplace.txt
@@ -45,6 +45,9 @@ properly, and that not all operations are supported.
                         (rather than a Nashorn) env with the port set to the
                         number provided.
 
+                        The default environment can be configured using
+                        |g:fireplace_default_cljs_repl| option.
+
 :Piggieback!            Terminate the most recently created piggieback
                         session.
 
@@ -184,6 +187,28 @@ And insert mode:
 
 There's omnicomplete on |CTRL-X_CTRL-O|, which works in Clojure buffers and
 in the |command-line-window|, and tab complete at the cqp prompt.
+
+OPTIONS                                         *fireplace-options*
+
+                                                *'g:fireplace_default_cljs_repl'*
+g:fireplace_default_cljs_repl
+                        Sets the default ClojureScript REPL environment. This
+                        is used when evaluating code in cljs files without
+                        active Cljs REPL connection or when calling
+                        |fireplace-:Piggieback| command without arguments.
+
+Default repl-env is: >
+  (cljs.repl.nashorn/repl-env)
+
+To disable default REPL use empty string: >
+  let g:fireplace_default_cljs_repl = ''
+
+To use different REPL environment use: >
+  let g:fireplace_default_cljs_repl = "(do (require 'cljs.repl.node) ((resolve 'cljs.repl.node/repl-env)))"
+
+Note that you need to require the repl namespace yourself and use {resolve} to
+refer to the function. This is because the symbol is not available before
+namespace is loaded.
 
 ABOUT                                           *fireplace-about*
 

--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -307,8 +307,15 @@ function! s:repl.piggieback(arg, ...) abort
 
   let connection = s:conn_try(self.connection, 'clone')
   if empty(a:arg)
-    call connection.eval("(require 'cljs.repl.nashorn)")
-    let arg = '(cljs.repl.nashorn/repl-env)'
+    if exists("g:fireplace_default_cljs_repl")
+      let arg = g:fireplace_default_cljs_repl
+      if empty(arg)
+        return {'ex': 'No cljs repl available'}
+      endif
+    else
+      call connection.eval("(require 'cljs.repl.nashorn)")
+      let arg = '(cljs.repl.nashorn/repl-env)'
+    endif
   elseif a:arg =~# '^\d\{1,5}$'
     let replns = 'weasel.repl.websocket'
     if has_key(connection.eval("(require '" . replns . ")"), 'ex')


### PR DESCRIPTION
I find it inconvenient that if I accidentally hit `cpp` in `.cljs` files, or when using omnicomplete, when I don't have browser repl connection set up, Vim stops for few seconds opening up Nashorn REPL, so I'd like to have option to disable default Nashorn REPL creation.

Cljs also nowadays supports many other REPL environments, like Node.js, Graal.JS and Rhino so I think it would be good idea to provide option to control this.