### PR TITLE
Fixed bug where fireplace#path was empty for me

### DIFF
--- a/plugin/fireplace.vim
+++ b/plugin/fireplace.vim
@@ -664,7 +664,12 @@ function! fireplace#path(...) abort
       return repl.path()
     endif
   endfor
-  return s:path_extract(getbufvar(buf, '&path'))
+  let res = s:path_extract(getbufvar(buf, '&path'))
+  if len(res) == 0
+    return split(fireplace#evalparse('(System/getProperty "java.class.path")'), ':')
+  else
+    return res
+  endif
 endfunction
 
 function! fireplace#platform(...) abort


### PR DESCRIPTION
This basically adds another fallback option to get the classpath.  I'm not sure exactly why the other options didn't work, but know that this one does!  My problem was similar to this one:

https://stackoverflow.com/questions/28499823/vim-fireplace-cannot-find-source-files-when-jumping-to-symbols

but I'm not on windows and am using different versions for things.  