### PR TITLE
Reduce visual "jumping" on successful RunTest

### DIFF
--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -1840,17 +1840,17 @@ function! fireplace#capture_test_run(expr, ...) abort
         \ . ' (catch Exception e'
         \ . '   (clojure.core/println (clojure.core/str e))'
         \ . '   (clojure.core/println (clojure.string/join "\n" (.getStackTrace e)))))'
-  call setqflist([], ' ', {'title': a:expr})
   let was_qf = &buftype ==# 'quickfix'
-  botright copen
+  botright cwindow
   if &buftype ==# 'quickfix' && !was_qf
     wincmd p
   endif
+  call setqflist([], ' ', {'title': a:expr})
   call fireplace#message({'op': 'eval', 'code': expr, 'session': 0},
-        \ function('s:handle_test_response', [[], get(getqflist({'id': 0}), 'id'), fireplace#path()]))
+        \ function('s:handle_test_response', [[], get(getqflist({'id': 0}), 'id'), fireplace#path(), a:expr]))
 endfunction
 
-function! s:handle_test_response(buffer, id, path, message) abort
+function! s:handle_test_response(buffer, id, path, expr, message) abort
   let str = get(a:message, 'out', '') . get(a:message, 'err', '')
   if empty(a:buffer)
     let str = substitute(str, "^\r\\=\n", "", "")
@@ -1895,6 +1895,7 @@ function! s:handle_test_response(buffer, id, path, message) abort
       wincmd p
     endif
   endif
+  echo a:expr
 endfunction
 
 function! s:RunTests(bang, count, ...) abort

--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -1894,8 +1894,8 @@ function! s:handle_test_response(buffer, id, path, expr, message) abort
     if &buftype ==# 'quickfix' && !was_qf
       wincmd p
     endif
+    echo a:expr
   endif
-  echo a:expr
 endfunction
 
 function! s:RunTests(bang, count, ...) abort


### PR DESCRIPTION
On my machine, the current implementation causes the quickfix window to
jump up and back down on a successful test run, and/or causes a "Press
ENTER to continue" prompt from the combination of the quickfix window
opening and echoing the test command.

This commit changes `copen` to `cwindow`, but moves the qflist clearing
to after that call. This keeps the quickfix window open if it was
already (there's a slight flash) on errors, but prevents the jumping on
a successful run. This also re-echos the test command after the results
come back to more clearly indicate a successful run, similar to how it
felt before the new async stuff.

I also tried conditionally using copen by checking the qflist contents
before clearing, but the list wasn't empty on a successful run, so there
might be something else hiding the window in that case that I'm not
aware of....