### PR TITLE
Handle early transport exit

### DIFF
--- a/autoload/fireplace/transport.vim
+++ b/autoload/fireplace/transport.vim
@@ -150,7 +150,9 @@ function! s:json_callback(url, state, requests, sessions, job, msg) abort
 endfunction
 
 function! s:exit_callback(url, state, requests, sessions, job, status) abort
-  call remove(s:urls, a:url)
+  if has_key(s:urls, a:url)
+    call remove(s:urls, a:url)
+  endif
   let a:state.exit = a:status
 endfunction
 


### PR DESCRIPTION
If the remote end terminates the connection before sending a "status"
message, `exit_callback` will be called before the transport is
registered for the url. This can be reproduced by trying to Piggieback
onto a shadow-cljs repl as if it were a figwheel repl (ex: `Piggeback
(figwheel-sidecar.repl-api/repl-env)` instead of `Piggieback :app`)