### PR TITLE
[FIX] qualify "when-not" and "find-ns" with clojure.core

### DIFF
--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -309,9 +309,9 @@ function! s:repl.preload(lib) dict abort
     let self.requires[a:lib] = 0
     if self.user_ns() ==# 'user'
       let qsym = s:qsym(a:lib)
-      let expr = '(when-not (find-ns '.qsym.') (try'
+      let expr = '(clojure.core/when-not (clojure.core/find-ns '.qsym.') (try'
             \ . ' (#''clojure.core/load-one '.qsym.' true true)'
-            \ . ' (catch Exception e (when-not (find-ns '.qsym.') (throw e)))))'
+            \ . ' (catch Exception e (clojure.core/when-not (clojure.core/find-ns '.qsym.') (throw e)))))'
     else
       let expr = '(ns '.self.user_ns().' (:require '.a:lib.reload.'))'
     endif


### PR DESCRIPTION
Once connected to a repl, when trying to evaluate any form I get the error: "java.lang.RuntimeException: Unable to resolve symbol: when-not in this context"
