### PR TITLE
Provide jar handling for java source jumping

### DIFF
--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -1798,7 +1798,7 @@ endfunction
 
 function! fireplace#info(symbol) abort
   if fireplace#op_available('info')
-    let response = fireplace#message({'op': 'info', 'symbol': a:symbol, 'ns': fireplace#ns()}, v:t_dict)
+    let response = fireplace#message({'op': 'info', 'symbol': a:symbol}, v:t_dict)
     if type(get(response, 'value')) == type({})
       return response.value
     elseif has_key(response, 'file') || has_key(response, 'doc')

--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -1798,7 +1798,7 @@ endfunction
 
 function! fireplace#info(symbol) abort
   if fireplace#op_available('info')
-    let response = fireplace#message({'op': 'info', 'symbol': a:symbol}, v:t_dict)
+    let response = fireplace#message({'op': 'info', 'symbol': a:symbol, 'ns': fireplace#ns()}, v:t_dict)
     if type(get(response, 'value')) == type({})
       return response.value
     elseif has_key(response, 'file') || has_key(response, 'doc')
@@ -1842,10 +1842,13 @@ function! fireplace#source(symbol) abort
   let info = fireplace#info(a:symbol)
 
   let file = ''
-  if !empty(get(info, 'resource'))
-    let file = fireplace#findresource(info.resource)
-  elseif get(info, 'file', '') =~# '^file:'
+  if get(info, 'file', '') =~# '^file:'
     let file = substitute(strpart(info.file, 5), '/', s:slash(), 'g')
+  elseif get(info, 'file', '') =~# '^jar:file:'
+    let zip = matchstr(info.file, '^jar:file:\zs.*\ze!')
+    let file = 'zipfile:' . zip . '::' . info.resource
+  elseif !empty(get(info, 'resource'))
+    let file = fireplace#findresource(info.resource)
   else
     let file = get(info, 'file', '')
   endif

--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -1842,15 +1842,19 @@ function! fireplace#source(symbol) abort
   let info = fireplace#info(a:symbol)
 
   let file = ''
-  if get(info, 'file', '') =~# '^file:'
-    let file = substitute(strpart(info.file, 5), '/', s:slash(), 'g')
-  elseif get(info, 'file', '') =~# '^jar:file:'
-    let zip = matchstr(info.file, '^jar:file:\zs.*\ze!')
-    let file = 'zipfile:' . zip . '::' . info.resource
-  elseif !empty(get(info, 'resource'))
+  if !empty(get(info, 'resource'))
     let file = fireplace#findresource(info.resource)
-  else
-    let file = get(info, 'file', '')
+  endif
+
+  if empty(file)
+    if get(info, 'file', '') =~# '^file:'
+      let file = substitute(strpart(info.file, 5), '/', s:slash(), 'g')
+    elseif get(info, 'file', '') =~# '^jar:file:'
+      let zip = matchstr(info.file, '^jar:file:\zs.*\ze!')
+      let file = 'zipfile:' . zip . '::' . info.resource
+    else
+      let file = get(info, 'file', '')
+    endif
   endif
 
   if !empty(file) && !empty(get(info, 'line', ''))


### PR DESCRIPTION
This change passes through ns when making the call to info and handles the case when referenced code is included on the classpath as a zip file (typical for java source e.g `/usr/lib/jvm/java-10-openjdk/src.zip`)

This should mean that you can jump to java source code using FireplaceDJump (I've tested this on Vim 8.1 with patches 1-1776 and Neovim v0.3.8)

Special thanks to @SevereOverfl0w for helping put this together with me :1st_place_medal: 