### PR TITLE
Support jumping to all Clojure's symbols

### DIFF
--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -50,7 +50,7 @@ endfunction
 function! s:cword() abort
   let isk = &l:iskeyword
   try
-    setlocal iskeyword+='
+    setlocal iskeyword+=',#,%,&
     return substitute(expand('<cword>'), "^''*", '', '')
   finally
     let &l:iskeyword = isk


### PR DESCRIPTION
This PR supports jumping to all Clojure's symbols.

In [reference about Symbols](https://clojure.org/reference/reader#_symbols),

>Symbols begin with a non-numeric character and can contain alphanumeric characters and *, +, !, -, _, ', ?, <, > and = (other characters may be allowed eventually).

I think that other characters mean `/`, `#`, `%` and `&`. `/` has already been included in iskeyword in [Vim8.1](https://github.com/vim/vim/blob/v8.1.0000/runtime/ftplugin/clojure.vim#L20) and in [Neovim v0.3.8](https://github.com/neovim/neovim/blob/v0.3.8/runtime/ftplugin/clojure.vim#L20), so I added others to iskeyword.