### PR TITLE
Update 'cider-nrepl via CLJ' documentation link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ two-second delay is vastly preferable to being forced out of my flow for a
 single command, in my book.
 
 [cider-nrepl]: https://github.com/clojure-emacs/cider-nrepl
-[cider-nrepl-via-clj]: https://github.com/clojure-emacs/cider-nrepl#via-clj
+[cider-nrepl-via-clj]: https://docs.cider.mx/cider-nrepl/usage.html#via-clj
 [Piggieback]: https://github.com/nrepl/piggieback
 [Clojure CLI]: https://clojure.org/guides/deps_and_cli
 [classpath.vim]: https://github.com/tpope/vim-classpath


### PR DESCRIPTION
## What?
Updated the link to cider-nrepl's "With CLJ" page in the Readme.

## Why?
Link to cider-nrepl's "With CLJ" documentation appears to have changed. The updated link now points to https://docs.cider.mx/cider-nrepl/usage.html#via-clj which should be a more stable URL, instead of the Readme in the GitHub repo.