### PR TITLE
Use faster get_complete_context in nvim-0.5

### DIFF
--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -192,7 +192,7 @@ function! s:candidate(val) abort
         \ }
 endfunction
 
-function! s:get_complete_context() abort
+function! s:internal_get_complete_context() abort
   " Find toplevel form
   " If cursor is on start parenthesis we don't want to find the form
   " If cursor is on end parenthesis we want to find the form
@@ -222,6 +222,14 @@ function! s:get_complete_context() abort
 
   return strpart(expr, 0, p) . ' __prefix__ ' . strpart(expr, p)
 endfunction
+
+if has('nvim-0.5')
+  let s:lua_impl = luaeval("require'_fireplace'")
+else
+  let s:lua_impl = {}
+endif
+
+let s:get_complete_context = get(s:lua_impl, 'get_completion_context', function('s:internal_get_complete_context'))
 
 function! s:complete_extract(msg) abort
   let trans = '{"word": (v:val =~# ''[./]'' ? "" : matchstr(a:base, ''^.\+/'')) . v:val}'

--- a/lua/_fireplace.lua
+++ b/lua/_fireplace.lua
@@ -1,0 +1,43 @@
+local fireplace_impl = {[vim.type_idx] = vim.types.dictionary}
+
+if vim.treesitter then
+  local has_ts, ts = pcall(require, 'nvim-treesitter.ts_utils')
+
+  if has_ts and vim.treesitter.language.add('clojure') then
+    fireplace_impl['get_completion_context'] = function()
+      vim.treesitter.get_parser(0, 'clojure'):parse()
+      local node = ts.get_node_at_cursor()
+      local one_ago = nil
+      local two_ago = nil
+
+      while(node ~= nil) do
+        two_ago = one_ago
+        one_ago = node
+        node = node:parent()
+      end
+
+      local root_node = two_ago or one_ago or node
+
+      if root_node ~= nil then
+        local strs = ts.get_node_text(root_node)
+        local nrow1, ncol1, nline2, ncol2 = root_node:range()
+        local crow, ccol = unpack(vim.api.nvim_win_get_cursor(0))
+
+        local idx = crow - nrow1
+        local line = strs[idx]
+        local coloffset = 0
+        if crow == nrow1 then
+          coloffset = ncol1
+        end
+
+        strs[idx] = string.sub(line, 1 + coloffset, ccol + coloffset) .. ' __prefix__ ' .. string.sub(line, ccol+coloffset+1, -1)
+
+        return table.concat(strs, "\n")
+      else
+        return ""
+      end
+    end
+  end
+end
+
+return fireplace_impl


### PR DESCRIPTION
For users using an "autocomplete" package of some kind (so completion on
every key press), a slow completion function adds noticeable lag to
typing.  The use of searchpairpos really slows down the current context
implementation.

Since nvim-0.5, there's a treesitter package included.  Treesitter can
incrementally parse the tree, and offers a very fast way to find the
root node.

I've benchmarked before & after using the clip library and get_complete_context goes from 6.244431 to 0.027365 self time (I will include the profile in a comment, as I cannot upload a file to a PR).

I've implemented this such that existing vim users will experience no degradation, that's required gymnastics in defining s:get_complete_context.  To keep s:get_complete_context very fast, I've avoided conditionals which won't change while vim is running.