### PR TITLE
`zipfile:` -> `zipfile://` to fix jump to definition issues due to pi_zip v32 changes

### DIFF
--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -1152,7 +1152,7 @@ function! fireplace#findresource(resource, ...) abort
   for dir in a:0 ? a:1 : fireplace#path()
     for suffix in suffixes
       if fnamemodify(dir, ':e') ==# 'jar' && index(fireplace#jar_contents(dir), resource . suffix) >= 0
-        return 'zipfile:' . dir . '::' . resource . suffix
+        return 'zipfile://' . dir . '::' . resource . suffix
       elseif filereadable(dir . '/' . resource . suffix)
         return dir . s:slash() . resource . suffix
       endif

--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -1152,7 +1152,11 @@ function! fireplace#findresource(resource, ...) abort
   for dir in a:0 ? a:1 : fireplace#path()
     for suffix in suffixes
       if fnamemodify(dir, ':e') ==# 'jar' && index(fireplace#jar_contents(dir), resource . suffix) >= 0
-        return 'zipfile://' . dir . '::' . resource . suffix
+        if get(g:, 'loaded_zipPlugin')[1:-1] > 31
+          return 'zipfile://' . dir . '::' . resource . suffix
+        else
+          return 'zipfile:' . dir . '::' . resource . suffix
+        endif
       elseif filereadable(dir . '/' . resource . suffix)
         return dir . s:slash() . resource . suffix
       endif


### PR DESCRIPTION
currently jump to definition is broken due to `zipfile:/home/me/foo.jar::file.clj` not opening in vim.

looking at `:help zip` I found that v32 of pi_zip has changed:
```
   v32 Oct 22, 2021 * to avoid an issue with a vim 8.2 patch, zipfile: has
                      been changed to zipfile:// . This often shows up
                      as zipfile:/// with zipped files that are root-based.
```

Note that I'm unsure how this change works with earlier versions pi_zip's zipfile