### PR TITLE
Ignore lines starting with #! when finding ns

### DIFF
--- a/autoload/fireplace.vim
+++ b/autoload/fireplace.vim
@@ -865,7 +865,7 @@ function! fireplace#ns(...) abort
     return getbufvar(buffer, 'fireplace_ns')
   endif
   let head = getbufline(buffer, 1, 500)
-  let blank = '^\s*\%(;.*\)\=$'
+  let blank = '^\s*\%(\%(;\|#!\).*\)\=$'
   call filter(head, 'v:val !~# blank')
   let keyword_group = '[A-Za-z0-9_?*!+/=<>.-]'
   let lines = join(head[0:49], ' ')


### PR DESCRIPTION
As per the discussion here https://github.com/tpope/vim-fireplace/issues/401#issuecomment-1342299148 , this commit changes the blank regex when looking for ns declarations to include `#!`, which improves compatibility with babashka scripts. (It doesn't completely resolve the original issue in the commit).