### PR TITLE
Use correct Python executable on Windows

### DIFF
--- a/autoload/fireplace/transport.vim
+++ b/autoload/fireplace/transport.vim
@@ -8,7 +8,11 @@ let g:autoloaded_fireplace_transport = 1
 
 let s:python_dir = fnamemodify(expand("<sfile>"), ':p:h:h:h') . '/pythonx'
 if !exists('g:fireplace_python_executable')
-  let g:fireplace_python_executable = executable('python3') ? 'python3' : 'python'
+  if has('win32')
+    let g:fireplace_python_executable = 'python'
+  else
+    let g:fireplace_python_executable = executable('python3') ? 'python3' : 'python'
+  endif
 endif
 
 if !exists('s:id')


### PR DESCRIPTION
Starting with Windows 10, Microsoft added Python aliases to the system, meaning you can type either `python.exe` or `python3.exe` in a Command Prompt and it'll redirect you to the Microsoft Store to download Python. 

When Python is installed on Windows only `python.exe` is created, there is no `python3.exe` even if Python 3 was installed, but there's still that Python 3 alias hanging around which causes a problem in the following code:

```vim
let g:fireplace_python_executable = executable('python3') ? 'python3' : 'python'
```

`python3.exe` will always be found as executable on Windows 10. 

Later in the file when this executable is used it of course doesn't work because it's bogus with the following error: `Fireplace: Connection Error: Failed to run command python3 .../vim-fireplace/pythonx/fireplace.py`

You can set `g:fireplace_python_executable` in your user `.vimrc` and get rid of this problem, but I wanted this to just work for people that have no patience for source code spelunking and trying to understand Microsoft logic.

I'm sure this is not the best way to do this. I'd be happy if there's a better way.