### PR TITLE
Add support for AF_UNIX socket connections

### DIFF
--- a/autoload/fireplace/transport.vim
+++ b/autoload/fireplace/transport.vim
@@ -169,16 +169,20 @@ augroup fireplace_transport
 augroup END
 
 function! fireplace#transport#connect(arg) abort
-  let url = substitute(a:arg, '#.*', '', '')
-  if url =~# '^\d\+$'
-    let url = 'nrepl://localhost:' . url
-  elseif url =~# '^[^:/@]\+\(:\d\+\)\=$'
-    let url = 'nrepl://' . url
-  elseif url !~# '^\a\+://'
-    throw "Fireplace: invalid connection string " . string(a:arg)
+  if a:arg =~# '^nrepl+unix:.*'
+    let url = a:arg
+  else
+    let url = substitute(a:arg, '#.*', '', '')
+    if url =~# '^\d\+$'
+      let url = 'nrepl://localhost:' . url
+    elseif url =~# '^[^:/@]\+\(:\d\+\)\=$'
+      let url = 'nrepl://' . url
+    elseif url !~# '^\a\+://'
+      throw "Fireplace: invalid connection string " . string(a:arg)
+    endif
+    let url = substitute(url, '^\a\+://[^/]*\zs$', '/', '')
+    let url = substitute(url, '^nrepl://[^/:]*\zs/', ':7888/', '')
   endif
-  let url = substitute(url, '^\a\+://[^/]*\zs$', '/', '')
-  let url = substitute(url, '^nrepl://[^/:]*\zs/', ':7888/', '')
   if has_key(s:urls, url)
     return s:urls[url].transport
   endif


### PR DESCRIPTION
Resolves #417.

A draft for adding support for connecting to AF_UNIX domain socket nREPL servers (the type that nREPL starts when you provide the `--socket PATH` option). 

If the user calls `FireplaceConnect` with a string starting with `nrepl+unix:`, we'll take the remainder of the string as a path to the domain socket and create a Python socket 

This is a proof of concept—I imagine we'd like to do something more elegant than a "magic string prefix" to allow users to ask for such a connection and for the Vimscript portion of the plugin to tell the Python portion to initiate one, but we're already pushing up against the limits of my Vimscript and Python skills :)